### PR TITLE
Add support for rbenv existing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ used throughout AgileVentures projects. This includes the following tools:
 * [curl](http://curl.haxx.se/)
 * [bundler](http://bundler.io/)
 * [RVM](https://rvm.io/)
+* Support for existing [rbenv](https://github.com/sstephenson/rbenv/) users
 * [nodejs](http://nodejs.org/) and [npm](https://www.npmjs.org/)
 * Options:
  - `$REQUIRED_RUBY` - specifies the required ruby version

--- a/scripts/rails_setup.sh
+++ b/scripts/rails_setup.sh
@@ -103,7 +103,7 @@ echo "
 # Only if rbenv is present install plugins
 if hash rbenv 2>/dev/null; then
   if ls -la ~/.rbenv/plugins/ruby-build &> /dev/null && \
-    ls -la ~/.rbenv/plugins/rbenv-gems &> /dev/null; then
+    ls -la ~/.rbenv/plugins/rbenv-gemset &> /dev/null; then
     if ! rbenv versions | grep $REQUIRED_RUBY; then
       rbenv install $REQUIRED_RUBY
     fi
@@ -111,11 +111,11 @@ if hash rbenv 2>/dev/null; then
     echo "$GEMSET" > .rbenv-gemsets
   else
     wget https://raw.githubusercontent.com/neosb/rbenv-install/master/rbenv-install
-    if ! ls -la ~/.rbenv/plugins/rbenv-gems &> /dev/null; then
+    if ! ls -la ~/.rbenv/plugins/rbenv-gemset &> /dev/null; then
       source rbenv-install --only-rbenv-gemset
       echo "$GEMSET" > .rbenv-gemsets
     fi
-    if ! ls -la ~/.rbenv/plugins/rbenv-gems &> /dev/null; then
+    if ! ls -la ~/.rbenv/plugins/ruby-build &> /dev/null; then
       source rbenv-install --only-ruby-build
       rbenv install $REQUIRED_RUBY
       echo "$REQUIRED_RUBY" > .ruby-version

--- a/scripts/rails_setup.sh
+++ b/scripts/rails_setup.sh
@@ -108,12 +108,12 @@ if hash rbenv 2>/dev/null; then
       rbenv install $REQUIRED_RUBY
     fi
     echo "$REQUIRED_RUBY" > .ruby-version
-    echo "agileventures" > .rbenv-gemsets
+    echo "$GEMSET" > .rbenv-gemsets
   else
     wget https://raw.githubusercontent.com/neosb/rbenv-install/master/rbenv-install
     if ! ls -la ~/.rbenv/plugins/rbenv-gems &> /dev/null; then
       source rbenv-install --only-rbenv-gemset
-      echo "agileventures" > .rbenv-gemsets
+      echo "$GEMSET" > .rbenv-gemsets
     fi
     if ! ls -la ~/.rbenv/plugins/rbenv-gems &> /dev/null; then
       source rbenv-install --only-ruby-build

--- a/scripts/rails_setup.sh
+++ b/scripts/rails_setup.sh
@@ -50,6 +50,7 @@ if [ $(uname) = "Linux" ]; then
   if [ -n "$HEADLESS" ]; then
       sudo apt-get install -y xvfb
   fi
+  sudo ln -s `which nodejs` /usr/bin/node
 
 elif [ $(uname) = "Darwin" ]; then
   if ! hash brew 2>/dev/null; then


### PR DESCRIPTION
I'm using rbenv and I want to contribute to [AgileVentures](https://www.agileventures.org/), thus I have changed the setup scripts, so that I and possibly other developers don't fall into problems with having both rvm and rbenv installed and prevent conflicts between them.
- Support is only for existing [rbenv](https://github.com/sstephenson/rbenv/) users, so if one don't have it installed my changes to setup script does nothing to them.
- Also there is an issue I couldn't resolve - installation of `ruby 2.1.1` on `Ubuntu 14.04` - there is a readline.so problem preventing Ruby to compile and I have statically made a decision for user to install `ruby 2.1.2` instead which compiles just fine.
- One more thing - Installation of `bundler` as a gem, because otherwise I would have to install older `ruby` systemwide first (like `1.9.1`), so it could install bundler, but I will not use it after the installation. `nodejs` package for `Ubuntu 14.04` already contains `npm` and `nodejs-dev`, and I have changed this, enabling installation of packages on `Ubuntu 14.04` - otherwise it won't start, but will execute other commands - this is not what installation script should do. 
- Something is terribly wrong with `nodejs-legacy` package for `Ubuntu 14.04`, so that I had to add manual symlink to nodejs as node in user's `PATH`
